### PR TITLE
Loosen dependency on Rails

### DIFF
--- a/bplgeo.gemspec
+++ b/bplgeo.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "~> 4.0.1"
+  s.add_dependency "rails", "~> 4.0"
   s.add_dependency "countries"
   s.add_dependency "geocoder"
   s.add_dependency 'unidecoder'


### PR DESCRIPTION
This is possibly a temporary fix until the Rails dependency can be removed. In the meanwhile, it allows use on 4.1.x, which has been tested.

At least partially addresses #4.
