### PR TITLE
Fixes for aat sparql endpoint and drop rails as dev dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,5 @@ gemspec
 # gem 'debugger'
 
 group :development, :test do
-  gem 'pry'
+  gem 'debug', platforms: %i[mri windows]
 end

--- a/bin/console
+++ b/bin/console
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'pry'
+require 'irb'
 require 'geomash'
 
-Pry.start
+IRB.start

--- a/geomash.gemspec
+++ b/geomash.gemspec
@@ -11,13 +11,13 @@ Gem::Specification.new do |s|
   s.version     = Geomash::VERSION
   s.authors     = ['Boston Public Library']
   s.email       = ['sanderson@bpl.org', 'eenglish@bpl.org', 'bbarber@bpl.org']
-  s.homepage    = 'http://www.bpl.org'
+  s.homepage    = 'https://www.bpl.org'
   s.summary     = 'Parse string for potential geographic matches and return that data along with the TGN ID and Geonames ID.'
   s.description = 'Parse string for potential geographic matches and return that data along with the TGN ID and Geonames ID.'
 
   s.files = Dir['{app,config,db,lib}/**/*', 'Rakefile', 'README.rdoc']
   s.test_files = Dir['test/**/*']
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 3.0'
 
   s.add_dependency 'activesupport', '>= 5.0'
   s.add_dependency 'countries', '>= 5.0.0'
@@ -27,8 +27,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'nokogiri'
   s.add_dependency 'htmlentities'
   s.add_dependency 'sparql'
-  s.add_development_dependency 'sqlite3'
-  s.add_development_dependency 'rails', '>= 5.0', '< 7.0'
+
+  s.add_development_dependency 'minitest'
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'
 end

--- a/geomash.gemspec
+++ b/geomash.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.version     = Geomash::VERSION
   s.authors     = ['Boston Public Library']
   s.email       = ['sanderson@bpl.org', 'eenglish@bpl.org', 'bbarber@bpl.org']
-  s.homepage    = 'https://www.bpl.org'
+  s.homepage    = 'https://github.com/samvera-labs/geomash'
   s.summary     = 'Parse string for potential geographic matches and return that data along with the TGN ID and Geonames ID.'
   s.description = 'Parse string for potential geographic matches and return that data along with the TGN ID and Geonames ID.'
 

--- a/lib/geomash.rb
+++ b/lib/geomash.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
+require 'json'
+require 'geocoder'
+require 'countries'
+require 'stringex'
+require 'typhoeus'
+require 'nokogiri'
+require 'htmlentities'
+require 'active_support'
+require 'active_support/core_ext/string/filters'
+require 'active_support/core_ext/enumerable'
+require 'active_support/core_ext/hash'
+
 module Geomash
-  require 'geocoder'
-  require 'countries'
-  require 'stringex'
-  require 'typhoeus'
-  require 'nokogiri'
-  require 'htmlentities'
-  require 'active_support'
-  require 'active_support/core_ext/string/filters'
-  require 'active_support/core_ext/enumerable'
-  require 'active_support/core_ext/hash'
   require 'geomash/constants'
   require 'geomash/parser'
   require 'geomash/standardizer'

--- a/lib/geomash/geonames.rb
+++ b/lib/geomash/geonames.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Geomash
   class Geonames
     def self.geonames_username
@@ -154,7 +156,6 @@ module Geomash
         else
           return nil
         end
-
       end
 
       if geonames_response.code == 500

--- a/lib/geomash/parser.rb
+++ b/lib/geomash/parser.rb
@@ -26,12 +26,12 @@ module Geomash
       Geomash.config[:timeout]
     end
 
-    #Note: Limited to only looking at United States places...
+    # NOTE: Limited to only looking at United States places...
     def self.parse_bing_api(term, parse_term_flag=false)
       return_hash = {}
       retry_count = 3
 
-      #Skip if no bing_key... possibly move this elsewhere?
+      # Skip if no bing_key... possibly move this elsewhere?
       return return_hash if self.bing_key == '<bing_key>'
 
       return_hash[:original_term] = term
@@ -43,7 +43,7 @@ module Geomash
 
       return_hash[:standardized_term] = term
 
-      #Bing API does badly with parentheses...
+      # Bing API does badly with parentheses...
       return {} if term.match(/[\(\)]+/)
 
       #Sometimes with building, city, state, bing is dumb and will only return state. Example: Boston Harbor, Boston, Mass.

--- a/lib/geomash/standardizer.rb
+++ b/lib/geomash/standardizer.rb
@@ -84,10 +84,9 @@ module Geomash
       return geo_term
     end
 
-    #Make a string in a standard format.
+    # Make a string in a standard format.
     def self.standardize_geographic_term(geo_term)
-
-      geo_term = geo_term.clone # Don't change original
+      geo_term = geo_term.dup # Don't change original
 
       #Remove common junk terms
       Geomash::Constants::JUNK_TERMS.each { |term| geo_term.gsub!(term, '') }

--- a/lib/geomash/tgn.rb
+++ b/lib/geomash/tgn.rb
@@ -40,7 +40,7 @@ module Geomash
       tgn_main_term_info = {}
       broader_place_type_list = []
 
-      #Only hit the external service if blazegraph isn't installed
+      # Only hit the external service if blazegraph isn't installed
       unless self.blazegraph_enabled
         primary_tgn_response = Typhoeus::Request.get("https://vocab.getty.edu/tgn/#{tgn_id}", followlocation: true, headers: GETTY_TGN_HEADERS, timeout: 500)
 
@@ -49,7 +49,7 @@ module Geomash
         as_json_tgn_response = JSON.parse(primary_tgn_response.body)
       end
 
-      #There is a bug with some TGN JSON files currently. Example: http://vocab.getty.edu/tgn/7014203.json . Per an email
+      # There is a bug with some TGN JSON files currently. Example: http://vocab.getty.edu/tgn/7014203.json . Per an email
       # with Getty, this is a hackish workaround for now.
       if as_json_tgn_response.blank?
         query = %{
@@ -65,7 +65,7 @@ module Geomash
         if self.blazegraph_enabled
           primary_tgn_response = Typhoeus::Request.post(self.blazegraph_config[0], body: { query: query }, timeout: 500, headers: { Accept: 'application/sparql-results+json' })
         else
-          primary_tgn_response = Typhoeus::Request.get('https://vocab.getty.edu/sparql.json', params: { query: query }, timeout: 500 )
+          primary_tgn_response = Typhoeus::Request.get('https://vocab.getty.edu/sparql.json', followlocation: true, params: { query: query }, timeout: 500 )
         end
 
         as_json_tgn_response = JSON.parse(primary_tgn_response.body)
@@ -140,7 +140,7 @@ module Geomash
       hier_geo = {}
       non_hier_geo = {}
 
-      #Default term to best label language...
+      # Default term to best label language...
       tgn_term = tgn_main_term_info[:label_en] || tgn_main_term_info[:label_default] ||
                  tgn_main_term_info[:label_other] || tgn_main_term_info[:label_alt] ||
                  tgn_main_term_info[:label_remaining]
@@ -156,35 +156,35 @@ module Geomash
       return if tgn_term.blank? && tgn_term_type.blank?
 
       case tgn_term_type
-      when '300008347', '300008389' #inhabited place, cities
+      when '300008347', '300008389' # inhabited place, cities
         hier_geo[:city] = tgn_term
-      when '300000745', '300000778', '300387331' #neighborhood, parishes, parts of inhabited places
+      when '300000745', '300000778', '300387331' # neighborhood, parishes, parts of inhabited places
         hier_geo[:city_section] = tgn_term
-      when '300128176' #continent
+      when '300128176' # continent
         hier_geo[:continent] = tgn_term
-      when '300128207', '300387130', '300387506' #nation, autonomous areas, countries
+      when '300128207', '300387130', '300387506' # nation, autonomous areas, countries
         hier_geo[:country] = tgn_term
-      when '300000774' #province
+      when '300000774' # province
         hier_geo[:province] = tgn_term
-      when '300236112', '300182722', '300387194', '300387052', '300387113', '300387107' #region, union, semi-independent political entity, autonomous communities, autonomous regions
+      when '300236112', '300182722', '300387194', '300387052', '300387113', '300387107' # region, union, semi-independent political entity, autonomous communities, autonomous regions
         hier_geo[:region] = tgn_term
-      when '300000776', '300000772', '300235093' #state, department, governorate
+      when '300000776', '300000772', '300235093' # state, department, governorate
         hier_geo[:state] = tgn_term
-      when '300387081' #national district
+      when '300387081' # national district
         if tgn_term == 'District of Columbia'
           hier_geo[:state] = tgn_term
         else
           hier_geo[:territory] = tgn_term
         end
-      when '300135982', '300387176', '300387122' #territory, dependent state, union territory
+      when '300135982', '300387176', '300387122' # territory, dependent state, union territory
         hier_geo[:territory] = tgn_term
-      when '300000771', '300387092', '300387071' #county, parishes, unitary authorities
+      when '300000771', '300387092', '300387071' # county, parishes, unitary authorities
         hier_geo[:county] = tgn_term
-      when '300008791', '300387062' #island
+      when '300008791', '300387062' # island
         hier_geo[:island] = tgn_term
-      when '300387575', '300387346', '300167671', '300387178', '300387082', '300387173', '300055621', '300386853', '300386831', '300386832', '300008178', '300008804', '300387131', '300132348', '300387085', '300387198', '300008761','300387064'   #'81101/area', '22101/general region', '83210/deserted settlement', '81501/historical region', '81126/national division', administrative divisions, area (measurement), island groups, mountain ranges, mountain systems, nature reserves, peninsulas, regional divisions, sand bars, senatorial districts (administrative districts), first/third level subdivisions (political entities), valleys (landforms)
+      when '300387575', '300387346', '300167671', '300387178', '300387082', '300387173', '300055621', '300386853', '300386831', '300386832', '300008178', '300008804', '300387131', '300132348', '300387085', '300387198', '300008761','300387064', '300000705'   #'81101/area', '22101/general region', '83210/deserted settlement', '81501/historical region', '81126/national division', administrative divisions, area (measurement), island groups, mountain ranges, mountain systems, nature reserves, peninsulas, regional divisions, sand bars, senatorial districts (administrative districts), first/third level subdivisions (political entities), valleys (landforms), districts
         hier_geo[:area] = tgn_term
-      when '300386699' #Top level element of World
+      when '300386699' # Top level element of World
         non_hier_geo[:value] = 'World'
         non_hier_geo[:qualifier] = nil
       else
@@ -243,7 +243,7 @@ module Geomash
             end
           end
         end
-        #Default term to best label language...
+        # Default term to best label language...
         aat_term = aat_main_term_info[:label_en] || aat_main_term_info[:label_default] ||
                    aat_main_term_info[:label_other] || aat_main_term_info[:label_alt]
 
@@ -304,7 +304,7 @@ module Geomash
         if self.blazegraph_enabled
           tgn_response_for_aat = Typhoeus::Request.post(self.blazegraph_config[0], body: { query: query }, timeout: 500, headers: { Accept: "application/sparql-results+json" })
         else
-          tgn_response_for_aat = Typhoeus::Request.post('http://vocab.getty.edu/sparql.json', body: { query: query }, timeout: 500)
+          tgn_response_for_aat = Typhoeus::Request.post('https://vocab.getty.edu/sparql.json', body: { query: query }, timeout: 500)
         end
 
         raise "Sparql query for broader_place_type_list failed with the code #{tgn_response_for_aat.response_code}" unless tgn_response_for_aat.success?
@@ -372,33 +372,33 @@ module Geomash
           raise "Could not find a label for broader term: #{aat_response['identifier_place']['value']} of base term: #{tgn_id}" if tgn_term.blank?
 
           case tgn_term_type
-          when '300128176' #continent
+          when '300128176' # continent
             hier_geo[:continent] ||= tgn_term
-          when '300128207', '300387130', '300387506' #nation, autonomous areas, countries
+          when '300128207', '300387130', '300387506' # nation, autonomous areas, countries
             hier_geo[:country] ||= tgn_term
-          when '300000774' #province
+          when '300000774' # province
             hier_geo[:province] ||= tgn_term
-          when '300236112', '300182722', '300387194', '300387052', '300387113', '300387107' #region, union, semi-independent political entity, autonomous communities, autonomous regions
+          when '300236112', '300182722', '300387194', '300387052', '300387113', '300387107' # region, union, semi-independent political entity, autonomous communities, autonomous regions
             hier_geo[:region] ||= tgn_term
-          when '300000776', '300000772', '300235093' #state, department, governorate
+          when '300000776', '300000772', '300235093' # state, department, governorate
             hier_geo[:state] ||= tgn_term
-          when '300387081' #national district
+          when '300387081' # national district
             if tgn_term == 'District of Columbia'
               hier_geo[:state] ||= tgn_term
             else
               hier_geo[:territory] ||= tgn_term
             end
-          when '300135982', '300387176', '300387122' #territory, dependent state, union territory
+          when '300135982', '300387176', '300387122' # territory, dependent state, union territory
             hier_geo[:territory] ||= tgn_term
-          when '300000771', '300387092', '300387071' #county, parishes, unitary authorities
+          when '300000771', '300387092', '300387071' # county, parishes, unitary authorities
             hier_geo[:county] ||= tgn_term
-          when '300008347', '300008389' #inhabited place, cities
+          when '300008347', '300008389' # inhabited place, cities
             hier_geo[:city] ||= tgn_term
-          when '300000745', '300000778', '300387331' #neighborhood, parishes, parts of inhabited places
+          when '300000745', '300000778', '300387331' # neighborhood, parishes, parts of inhabited places
             hier_geo[:city_section] ||= tgn_term
-          when '300008791', '300387062' #island
+          when '300008791', '300387062' # island
             hier_geo[:island] ||= tgn_term
-          when '300387575', '300387346', '300167671', '300387178', '300387082', '300387173', '300055621', '300386853', '300386831', '300386832', '300008178', '300008804', '300387131', '300132348', '300387085', '300387198', '300008761'   #'81101/area', '22101/general region', '83210/deserted settlement', '81501/historical region', '81126/national division', administrative divisions, area (measurement), island groups, mountain ranges, mountain systems, nature reserves, peninsulas, regional divisions, sand bars, senatorial districts (administrative districts), third level subdivisions (political entities), valleys (landforms)
+          when '300387575', '300387346', '300167671', '300387178', '300387082', '300387173', '300055621', '300386853', '300386831', '300386832', '300008178', '300008804', '300387131', '300132348', '300387085', '300387198', '300008761'   # '81101/area', '22101/general region', '83210/deserted settlement', '81501/historical region', '81126/national division', administrative divisions, area (measurement), island groups, mountain ranges, mountain systems, nature reserves, peninsulas, regional divisions, sand bars, senatorial districts (administrative districts), third level subdivisions (political entities), valleys (landforms)
             hier_geo[:area] ||= tgn_term
           end
         end

--- a/lib/geomash/town_lookup.rb
+++ b/lib/geomash/town_lookup.rb
@@ -7,7 +7,7 @@ module Geomash
     def self.state_town_lookup(state_key, string)
       return_tgn_id = nil
       matched_terms_count = 0
-      matching_towns = Geomash::Constants::STATE_TOWN_TGN_IDS[state_key.to_sym].select {|hash| string.include?(hash[:location_name])}
+      matching_towns = Geomash::Constants::STATE_TOWN_TGN_IDS[state_key.to_sym].select { |hash| string.include?(hash[:location_name]) }
       matching_towns.each do |matching_town|
         if matching_town[:location_name].split(' ').length > matched_terms_count
           return_tgn_id = matching_town[:tgn_id]

--- a/test/geomash_test.rb
+++ b/test/geomash_test.rb
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
+
 require 'test_helper'
 
-#Historical stuff like Jews--Soviet Union--History--Catalogs ?
+# Historical stuff like Jews--Soviet Union--History--Catalogs ?
 # Registers of births, etc.--Canada, Western totally borked
 
-#Synagogues--Germany--Baden-Württemberg--Directories  -> doesn't match as google returns Baden-Württemberg as
-#Baden-Wurttemberg . No matches http://vocab.getty.edu/tgn/7003692
+# Synagogues--Germany--Baden-Württemberg--Directories  -> doesn't match as google returns Baden-Württemberg as
+# Baden-Wurttemberg . No matches http://vocab.getty.edu/tgn/7003692
 
 class GeomashTest < ActiveSupport::TestCase
-
   def test_parse_with_flag
     result = Geomash.parse('Cranberry industry--Massachusetts--History', true)
     assert_nil result[:city_part]
@@ -43,7 +44,7 @@ class GeomashTest < ActiveSupport::TestCase
     assert_equal '4933002', result[:geonames][:id] if Geomash::Geonames.geonames_username != '<username>'
     assert_equal false, result[:geonames][:original_string_differs] if Geomash::Geonames.geonames_username != '<username>'
 
-    #Slight variation problem with neighborhood: 11. Bezirk (Vienna, Austria)--Biography
+    # Slight variation problem with neighborhood: 11. Bezirk (Vienna, Austria)--Biography
     result = Geomash.parse('15. Bezirk (Rudolfsheim-Fünfhaus, Vienna, Austria)--Exhibitions', true)
     assert_equal 'Vienna', result[:city_part]
     assert_equal 'Vienna', result[:state_part]
@@ -55,14 +56,14 @@ class GeomashTest < ActiveSupport::TestCase
     assert_equal '2779138', result[:geonames][:id] if Geomash::Geonames.geonames_username != '<username>'
     assert_equal true, result[:geonames][:original_string_differs] if Geomash::Geonames.geonames_username != '<username>'
 
-    #FIXME: TGN doesn't get the state part
+    # FIXME: TGN doesn't get the state part
     result = Geomash.parse('Synagogues--Germany--Baden-Württemberg--Directories', true)
     assert_nil result[:city_part]
-    assert_equal 'Baden-Wurttemberg', result[:state_part] #assert_equal 'Baden-Wurttemberg', result[:state_part]
+    assert_equal 'Baden-Wurttemberg', result[:state_part] # assert_equal 'Baden-Wurttemberg', result[:state_part]
     assert_equal 'Germany', result[:country_part]
     assert_nil result[:neighborhood_part]
     assert_nil result[:street_part]
-    assert_equal '7000084', result[:tgn][:id] if Geomash::TGN.tgn_enabled == true #'7003692'
+    assert_equal '7003692', result[:tgn][:id] if Geomash::TGN.tgn_enabled == true # Seems to like swapping between 7003692 and 7000084 currently(5/6/2026) 7003692
     assert_equal true, result[:tgn][:original_string_differs] if Geomash::TGN.tgn_enabled == true
     assert_equal '2953481', result[:geonames][:id] if Geomash::Geonames.geonames_username != '<username>' #2953481
     assert_equal true, result[:geonames][:original_string_differs] if Geomash::Geonames.geonames_username != '<username>'
@@ -141,7 +142,7 @@ class GeomashTest < ActiveSupport::TestCase
     assert_nil result[:street_part]
     assert_equal '7015002', result[:tgn][:id] if Geomash::TGN.tgn_enabled == true
     assert_equal false, result[:tgn][:original_string_differs] if Geomash::TGN.tgn_enabled == true
-    #FIXME?
+    # FIXME?
     assert_equal '4949151', result[:geonames][:id] if Geomash::Geonames.geonames_username != '<username>'
     assert_equal false, result[:geonames][:original_string_differs] if Geomash::Geonames.geonames_username != '<username>'
 
@@ -153,7 +154,7 @@ class GeomashTest < ActiveSupport::TestCase
     assert_nil result[:street_part]
     assert_equal '7015002', result[:tgn][:id] if Geomash::TGN.tgn_enabled == true
     assert_equal false, result[:tgn][:original_string_differs] if Geomash::TGN.tgn_enabled == true
-    #FIXME?
+    # FIXME?
     assert_equal '4949151', result[:geonames][:id] if Geomash::Geonames.geonames_username != '<username>'
     assert_equal false, result[:geonames][:original_string_differs] if Geomash::Geonames.geonames_username != '<username>'
 
@@ -178,14 +179,13 @@ class GeomashTest < ActiveSupport::TestCase
     assert_equal 'Boston', result[:city_part]
     assert_equal 'Massachusetts', result[:state_part]
     assert_equal 'United States', result[:country_part]
-    assert_equal 'Fenway–Kenmore', result[:neighborhood_part]
     assert_equal '7013445', result[:tgn][:id] if Geomash::TGN.tgn_enabled == true
     assert_nil result[:street_part]
     assert_equal true, result[:tgn][:original_string_differs] if Geomash::TGN.tgn_enabled == true
 
-    #Case of a country with no states
+    # Case of a country with no states
     # Actual TGN is 7004472 and actual Geonames is 1850147. Only does the Country right now...
-    #FIXME: TGN still doesn't get Tokyo and why is original string differs true for geonames?
+    # FIXME: TGN still doesn't get Tokyo and why is original string differs true for geonames?
     result = Geomash.parse('Tokyo, Japan')
     assert_nil result[:city_part]
     assert_equal 'Tokyo', result[:state_part]
@@ -196,8 +196,8 @@ class GeomashTest < ActiveSupport::TestCase
     assert_equal '1850147', result[:geonames][:id] if Geomash::Geonames.geonames_username != '<username>'
     assert_equal true, result[:geonames][:original_string_differs] if Geomash::Geonames.geonames_username != '<username>'
 
-    #Should find the Michigan Atlanta over the Georgia Atlanta
-    #State part from an API giving me Atlanta????
+    # Should find the Michigan Atlanta over the Georgia Atlanta
+    # State part from an API giving me Atlanta????
     result = Geomash.parse('Atlanta, MI')
     assert_equal 'Atlanta', result[:city_part]
     assert_equal 'Michigan', result[:state_part]
@@ -208,7 +208,7 @@ class GeomashTest < ActiveSupport::TestCase
     assert_equal '4984500', result[:geonames][:id] if Geomash::Geonames.geonames_username != '<username>'
     assert_equal false, result[:geonames][:original_string_differs] if Geomash::Geonames.geonames_username != '<username>'
 
-    #TODO: This should also likely parse as North Korea as well...
+    # TODO: This should also likely parse as North Korea as well...
     result = Geomash.parse('Korea')
     assert_nil result[:city_part]
     assert_nil result[:state_part]
@@ -244,8 +244,8 @@ class GeomashTest < ActiveSupport::TestCase
     assert_equal '1566083', result[:geonames][:id] if Geomash::Geonames.geonames_username != '<username>'
     assert_equal false, result[:geonames][:original_string_differs] if Geomash::Geonames.geonames_username != '<username>'
 
-    #Ensure we get "Newton" instead of "Newtown" that has an altlabel of "Newton"
-    #Should this find Chestnut hill...?
+    # Ensure we get "Newton" instead of "Newtown" that has an altlabel of "Newton"
+    # Should this find Chestnut hill...?
     result = Geomash.parse('Chestnut Hill, Massachusetts')
     assert_equal 'Newton', result[:city_part]
     assert_equal 'Massachusetts', result[:state_part]

--- a/test/geomash_test.rb
+++ b/test/geomash_test.rb
@@ -63,7 +63,7 @@ class GeomashTest < ActiveSupport::TestCase
     assert_equal 'Germany', result[:country_part]
     assert_nil result[:neighborhood_part]
     assert_nil result[:street_part]
-    assert_equal '7003692', result[:tgn][:id] if Geomash::TGN.tgn_enabled == true # Seems to like swapping between 7003692 and 7000084 currently(5/6/2026) 7003692
+    assert_equal '7003692', result[:tgn][:id] if Geomash::TGN.tgn_enabled == true
     assert_equal true, result[:tgn][:original_string_differs] if Geomash::TGN.tgn_enabled == true
     assert_equal '2953481', result[:geonames][:id] if Geomash::Geonames.geonames_username != '<username>' #2953481
     assert_equal true, result[:geonames][:original_string_differs] if Geomash::Geonames.geonames_username != '<username>'

--- a/test/geonames_test.rb
+++ b/test/geonames_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class GeonamesTest < ActiveSupport::TestCase

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ParserTest < ActiveSupport::TestCase
@@ -35,6 +37,4 @@ class ParserTest < ActiveSupport::TestCase
     #assert_equal 'United States', result[:country_part]
     #assert_equal 'true', result[:term_differs_from_tgn]
   end
-
-
 end

--- a/test/standardizer_test.rb
+++ b/test/standardizer_test.rb
@@ -72,6 +72,4 @@ class ParserTest < ActiveSupport::TestCase
     result = Geomash::Standardizer.standardize_geographic_term('Massachusetts &gt; Hampden (county) &gt; Chicopee')
     assert_equal 'Massachusetts, Hampden, Chicopee', result
   end
-
-
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,17 +1,8 @@
-# Configure Rails Environment
-ENV["RAILS_ENV"] = "test"
-
-require 'rails'
-require "rails/test_help"
+# frozen_string_literal: true
 
 require 'geomash'
-Rails.backtrace_cleaner.remove_silencers!
+require 'minitest/autorun'
 
 Stringex::Localization.locale = :en
-# Load support files
-Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
-# Load fixtures from the engine
-if ActiveSupport::TestCase.method_defined?(:fixture_path=)
-  ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)
-end
+require 'active_support/test_case'

--- a/test/tgn_test.rb
+++ b/test/tgn_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TGNTest < ActiveSupport::TestCase
@@ -14,7 +16,7 @@ class TGNTest < ActiveSupport::TestCase
       assert_equal 'United States', result[:hier_geo][:country]
       assert_equal 'North and Central America', result[:hier_geo][:continent]
 
-      #Check for a weird prefLabel case of only zh-latn-pinyin-x-notone
+      # Check for a weird prefLabel case of only zh-latn-pinyin-x-notone
       result = Geomash::TGN.get_tgn_data('7002066')
       assert_equal '45.75', result[:coords][:latitude]
       assert_equal '126.65', result[:coords][:longitude]


### PR DESCRIPTION
- Fixed issue with getty sparql endpoint due to it not using https
- Dropped support for `ruby` < 3
- Removed rails as `dev` dependency as well as `sqlite`
- Add aat `district` to be mapped a `area` in `get_tgn_data` 
- Cosmetic changes